### PR TITLE
Volume optimization revoked for rebalancer compatibillity & reader QOL

### DIFF
--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -1,5 +1,5 @@
 """
-Version 0.8
+Version 0.9
 
 This script does the following:
 - Removes the empty track FL creates and merges the tempo track with another track, allowing 16 channels to be used.

--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -219,6 +219,7 @@ def fix_program_changes(midi: MidiFile):
                 prgm_has_reverb = False
                 previous_pitch = 0
                 previous_reverb = 0
+                chnl_vol = 127
 
                 # inividual loop for each event to classify it
                 for m in range(len(track)):
@@ -260,9 +261,7 @@ def fix_program_changes(midi: MidiFile):
                                 # Volume and panning are reset on patch swap, so those are compared to the default values
                                 if msg.control == valid_CCs["volume"]:
                                     patch_event_time += msg.time
-                                    if msg.value != 127:
-                                        chnl_vol = msg.value
-                                        prgm_has_volume = True
+                                    chnl_vol = msg.value
                                 elif msg.control == valid_CCs["pan"]:
                                     patch_event_time += msg.time
                                     if msg.value != 64:
@@ -310,17 +309,16 @@ def fix_program_changes(midi: MidiFile):
                         ),
                     )
 
-                    if prgm_has_volume:
-                        track_messages_equal.insert(
-                            1,
-                            Message(
-                                "control_change",
-                                channel=program_msg.channel,
-                                time=0,
-                                control=valid_CCs["volume"],
-                                value=chnl_vol,
-                            ),
-                        )
+                    track_messages_equal.insert(
+                        1,
+                        Message(
+                            "control_change",
+                            channel=program_msg.channel,
+                            time=0,
+                            control=valid_CCs["volume"],
+                            value=chnl_vol,
+                        ),
+                    )
 
                     if prgm_has_panning:
                         track_messages_equal.insert(

--- a/tools/read_midi_file.py
+++ b/tools/read_midi_file.py
@@ -1,5 +1,8 @@
-# This script reads midi data back out to you
+"""
+Version 0.8
 
+This script reads midi data back out to you
+"""
 
 from mido import MidiFile
 from mido import MidiTrack
@@ -408,6 +411,7 @@ def read_midi(midi_file: str):
     set_sharp_or_flat("sharp")  # 'sharp' or 'flat'
     read_midi_data(midi)
     # read_single_track(midi, 1)  # Track number 1-16 or 1-18 before FL fixing
+    input("Press enter to close...")
 
 
 read_midi(filedialog.askopenfilename())


### PR DESCRIPTION
If a channels volume event is removed for optimization, the rebalancer will not be able to affect that channel's volume.
(tbh volume isn't much of a space saver anyway.)

Midi reader now pauses after reading before the terminal can close, if launched with cmd