### PR TITLE
Add new Insert Tempo file

### DIFF
--- a/tools/insert_tempo.py
+++ b/tools/insert_tempo.py
@@ -1,0 +1,19 @@
+from mido import MidiFile, MetaMessage
+import tkinter as tk
+from tkinter import filedialog
+
+root = tk.Tk()
+root.withdraw()
+
+def insert_tempo(midi: MidiFile):
+        midi.tracks[0].insert(0, MetaMessage('set_tempo'))
+
+def clean_midi(midi_file: str):
+    midi = MidiFile(midi_file)
+    print("\n" + midi_file + "\n")
+    insert_tempo(midi)
+    midi.save(midi_file.replace(".mid", "_tinserted.mid"))
+
+
+clean_midi(filedialog.askopenfilename())
+input("Press the Enter key to continue: ") 


### PR DESCRIPTION
This new file with add a `set_tempo` meta message in the first track of a midi, in the case that a midi file has no tempo event.