### PR TITLE
GIANT REFACTOR + other stuff

### DIFF
--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -1,5 +1,5 @@
 """
-Version 1.1.4
+Version 1.1.5
 
 This script does the following:
 - Removes the empty tracks FL creates and merges the tempo track with another track, allowing 16 channels to be used.
@@ -14,28 +14,19 @@ This script does the following:
 - Calls the overlap detector at the end, for convenience.
 """
 
-from mido import MidiFile
-from mido import MidiTrack
-from mido import Message
+from mido import MidiFile, MidiTrack, Message
 import tkinter as tk
-from tkinter import filedialog
 
-import small_libs.dk64_data as dk64data
-import small_libs.notes as note_names
+from small_libs.dk64_data import VALID_CC_EVENTS, get_pitch_range
+from small_libs.notes import set_sharp_or_flat
 import fix_patch_events as patcher
-import small_libs.common as common
+from small_libs.common import getMidiFile, find_tempo_track, find_notes_track
 
 from overlap_detector import check_overlap
 from voice_counter import check_voices
 
 root = tk.Tk()
 root.withdraw()
-
-valid_CCs = {
-    "volume": 7,
-    "reverb": 91,
-    "pan": 10,
-}
 
 
 def remove_empty_tracks(midi: MidiFile):
@@ -66,8 +57,8 @@ def find_insertion_point(target_track: MidiTrack, total_tempo_time: int):
 
 
 def move_tempo(midi: MidiFile):
-    tempo_track = midi.tracks[common.find_tempo_track(midi)]
-    target_track = common.find_notes_track(midi)
+    tempo_track = midi.tracks[find_tempo_track(midi)]
+    target_track = find_notes_track(midi)
     if target_track == "":
         input("ERROR: This file is empty; nowhere to place tempo...")
         exit(1)
@@ -150,7 +141,7 @@ def adjust_events(midi: MidiFile, todo: list):
                     # calls the function to return the bend range and give that to the function to use
                     elif "pitch-instrument" in todo:
                         msg.pitch = multiply_pitch(
-                            msg.pitch, dk64data.get_pitch_range(instrument)
+                            msg.pitch, get_pitch_range(instrument)
                         )
 
                 case "note_on":
@@ -158,7 +149,7 @@ def adjust_events(midi: MidiFile, todo: list):
                         msg.velocity = get_adjusted_volume(msg.velocity)
 
                 case "control_change":
-                    if msg.control == valid_CCs["volume"]:
+                    if msg.control == VALID_CC_EVENTS["volume"]:
                         if "volume" in todo:
                             msg.value = get_adjusted_volume(msg.value)
 
@@ -189,7 +180,7 @@ def remove_unrecognized_messages(midi: MidiFile):
                 if msg.type != "control_change":
                     good = True
                 else:
-                    if msg.control in valid_CCs.values():
+                    if msg.control in VALID_CC_EVENTS.values():
                         good = True
             if good:
                 filtered_messages.append(msg)
@@ -202,10 +193,9 @@ def remove_unrecognized_messages(midi: MidiFile):
 #
 
 
-def clean_midi(midi_file: str):
+def clean_midi(midi: MidiFile, path: str):
 
-    midi = MidiFile(midi_file)
-    print("\n" + midi_file + "\n")
+    print("\n" + path + "\n")
 
     remove_empty_tracks(midi)
     move_tempo(midi)
@@ -225,13 +215,13 @@ def clean_midi(midi_file: str):
     patcher.fix_program_changes(midi)
 
     # sets note names names to 'sharp' or 'flat', then checks for overlapping notes
-    note_names.set_sharp_or_flat("sharp")
+    set_sharp_or_flat("sharp")
     check_overlap(midi, True)
     check_voices(midi, True)
 
     # saves file with '_adjusted' added to the filename
-    midi.save(midi_file.replace(".mid", "_adjusted.mid"))
+    midi.save(path.replace(".mid", "_adjusted.mid"))
 
 
 if __name__ == "__main__":
-    clean_midi(common.getMidiFile())
+    clean_midi(*getMidiFile(path=True))

--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -18,14 +18,14 @@ from mido import MidiFile, MidiTrack, Message
 
 from small_libs.dk64_data import VALID_CC_EVENTS, get_pitch_range
 from small_libs.notes import set_sharp_or_flat
-from fix_patch_events import fix_program_changes
 from small_libs.common import getMidiFile, find_tempo_track, find_notes_track
 
+from fix_patch_events import fix_program_changes
 from overlap_detector import check_overlap
 from voice_counter import check_voices
 
 
-def remove_empty_tracks(midi: MidiFile):
+def remove_empty_tracks(midi: MidiFile) -> None:
     total_tracks = len(midi.tracks)
     track_no = 0
     for t in range(total_tracks):
@@ -43,7 +43,7 @@ def remove_empty_tracks(midi: MidiFile):
             track_no += 1
 
 
-def find_insertion_point(target_track: MidiTrack, total_tempo_time: int):
+def find_insertion_point(target_track: MidiTrack, total_tempo_time: int) -> tuple[int, int]:
     total_target_time = 0
     for index in range(len(target_track)):
         total_target_time += target_track[index].time
@@ -52,7 +52,7 @@ def find_insertion_point(target_track: MidiTrack, total_tempo_time: int):
     return len(target_track), total_target_time
 
 
-def move_tempo(midi: MidiFile):
+def move_tempo(midi: MidiFile) -> None:
     tempo_track = midi.tracks[find_tempo_track(midi)]
     target_track = find_notes_track(midi)
     if target_track == "":
@@ -79,20 +79,20 @@ def move_tempo(midi: MidiFile):
     del midi.tracks[0]
 
 
-def multiply_pitch(pitch: int, bend_range=2):
+def multiply_pitch(pitch: int, bend_range=2) -> int:
     new_pitch = int(pitch * (12 / bend_range))
     clamped_pitch = max(min(8191, new_pitch), -8192)
     return clamped_pitch
 
 
-def get_expected_FL_volume(velocity: int):
+def get_expected_FL_volume(velocity: int) -> float:
     # .62 / 127 ^ 2 * x ^ 2, max = .62
     # .002
     # x + .01, max = .264
     return (0.62 / (127**2)) * (velocity**2)
 
 
-def DK_volume_to_approx_velocity(volume: float):
+def DK_volume_to_approx_velocity(volume: float) -> int:
     # y = .002
     # x + 0.1
     # x = (y / .002)
@@ -101,7 +101,7 @@ def DK_volume_to_approx_velocity(volume: float):
     return round(approx_velocity)
 
 
-def get_adjusted_volume(velocity: int):
+def get_adjusted_volume(velocity: int) -> int:
     maxFL = 0.620
     maxDK = 0.264
     expected_FL_volume = get_expected_FL_volume(velocity)
@@ -111,7 +111,7 @@ def get_adjusted_volume(velocity: int):
     return adjusted_velocity
 
 
-def adjust_events(midi: MidiFile, todo: list):
+def adjust_events(midi: MidiFile, todo: list) -> None:
     """
     adjust_events does the following:
         adjusts the panning to, partially, match fl.
@@ -157,7 +157,7 @@ def adjust_events(midi: MidiFile, todo: list):
                             msg.value = get_adjusted_panning()"""
 
 
-def remove_unrecognized_messages(midi: MidiFile):
+def remove_unrecognized_messages(midi: MidiFile) -> None:
     accepted_messages = [
         "note_off",
         "note_on",
@@ -186,7 +186,7 @@ def remove_unrecognized_messages(midi: MidiFile):
         track[:] = filtered_messages
 
 
-def clean_midi(midi: MidiFile, path: str):
+def clean_midi(midi: MidiFile, path: str) -> None:
 
     print("\n" + path + "\n")
 
@@ -216,7 +216,7 @@ def clean_midi(midi: MidiFile, path: str):
     midi.save(path.replace(".mid", "_adjusted.mid"))
 
 
-def main():
+def main() -> None:
     clean_midi(*getMidiFile(path=True))
 
 

--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -1,17 +1,17 @@
 """
 Version 1.1.5
 
-This script does the following:
-- Removes the empty tracks FL creates and merges the tempo track with another track, allowing 16 channels to be used.
-- Multiplies all pitch values by 6 so they sound the same as in FL
-  - or alternativly multiplies to the proper instrument bend range. (see dk64_data.py for instrument ranges)
-- Converts velocity and volume events to the DK64 linear curve (as opposed to FL's exponential curve)
-  - The max volume of FL has to be adjusted by the user to compensate for DK64's max volume.
-- Removes unrecognized MIDI events
-- Deletes duplicate patch events caused by fl
-  - This also condenses the subsequent events on the same tick caused by patch changes.
-  - This means that fl midis no longer need to be offset or have events at the loop to fix the patch bug!!
-- Calls the overlap detector at the end, for convenience.
+- This script does the following:
+  - Removes the empty tracks FL creates and merges the tempo track with another track, allowing 16 channels to be used.
+  - Multiplies all pitch values by 6 so they sound the same as in FL.
+    - or alternativly multiplies to the proper instrument bend range. (see dk64_data.py for instrument ranges)
+  - Converts velocity and volume events to the DK64 linear curve (as opposed to FL's exponential curve)
+    - The max volume of FL has to be adjusted by the user to compensate for DK64's max volume.
+  - Removes unrecognized MIDI events.
+  - Deletes duplicate patch events caused by FL.
+    - This also condenses the subsequent events on the same tick caused by patch changes.
+    - This means that FL midis no longer need to be offset or have events at the loop to fix the patch bug!!
+  - Calls the overlap detector at the end, for convenience.
 """
 
 from mido import MidiFile, MidiTrack, Message

--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -15,7 +15,6 @@ This script does the following:
 """
 
 from mido import MidiFile, MidiTrack, Message
-import tkinter as tk
 
 from small_libs.dk64_data import VALID_CC_EVENTS, get_pitch_range
 from small_libs.notes import set_sharp_or_flat
@@ -24,9 +23,6 @@ from small_libs.common import getMidiFile, find_tempo_track, find_notes_track
 
 from overlap_detector import check_overlap
 from voice_counter import check_voices
-
-root = tk.Tk()
-root.withdraw()
 
 
 def remove_empty_tracks(midi: MidiFile):
@@ -190,9 +186,6 @@ def remove_unrecognized_messages(midi: MidiFile):
         track[:] = filtered_messages
 
 
-#
-
-
 def clean_midi(midi: MidiFile, path: str):
 
     print("\n" + path + "\n")
@@ -223,5 +216,9 @@ def clean_midi(midi: MidiFile, path: str):
     midi.save(path.replace(".mid", "_adjusted.mid"))
 
 
-if __name__ == "__main__":
+def main():
     clean_midi(*getMidiFile(path=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/adjust_FL_midi.py
+++ b/tools/adjust_FL_midi.py
@@ -18,7 +18,7 @@ from mido import MidiFile, MidiTrack, Message
 
 from small_libs.dk64_data import VALID_CC_EVENTS, get_pitch_range
 from small_libs.notes import set_sharp_or_flat
-import fix_patch_events as patcher
+from fix_patch_events import fix_program_changes
 from small_libs.common import getMidiFile, find_tempo_track, find_notes_track
 
 from overlap_detector import check_overlap
@@ -205,7 +205,7 @@ def clean_midi(midi: MidiFile, path: str):
     adjust_events(midi, ["pitch-instrument", "volume"])
     remove_unrecognized_messages(midi)
 
-    patcher.fix_program_changes(midi)
+    fix_program_changes(midi)
 
     # sets note names names to 'sharp' or 'flat', then checks for overlapping notes
     set_sharp_or_flat("sharp")

--- a/tools/change_expression_to_volume.py
+++ b/tools/change_expression_to_volume.py
@@ -4,7 +4,7 @@ from small_libs.common import getMidiFile
 global currentVolume
 
 
-def expression_to_volume(midi: MidiFile):
+def expression_to_volume(midi: MidiFile) -> None:
     for track in midi.tracks:
         for msg in track:
             match msg.type:
@@ -17,7 +17,7 @@ def expression_to_volume(midi: MidiFile):
                         msg.control = 7
 
 
-def main():
+def main() -> None:
     midi, path = getMidiFile()
     expression_to_volume(midi)
     midi.save(path.replace(".mid", "_e2v.mid"))

--- a/tools/change_expression_to_volume.py
+++ b/tools/change_expression_to_volume.py
@@ -1,10 +1,6 @@
 from mido import MidiFile
-import tkinter as tk
-from tkinter import filedialog
-import small_libs.common as common
+from small_libs.common import getMidiFile
 
-root = tk.Tk()
-root.withdraw()
 global currentVolume
 
 
@@ -21,12 +17,11 @@ def expression_to_volume(midi: MidiFile):
                         msg.control = 7
 
 
-def clean_midi(midi_file: str):
-    midi = MidiFile(midi_file)
-    print("\n" + midi_file + "\n")
+def main():
+    midi, path = getMidiFile()
     expression_to_volume(midi)
-    midi.save(midi_file.replace(".mid", "_e2v.mid"))
+    midi.save(path.replace(".mid", "_e2v.mid"))
 
 
-clean_midi(common.getMidiFile())
-input("Press the Enter key to continue: ")
+if __name__ == "__main__":
+    main()

--- a/tools/change_expression_to_volume.py
+++ b/tools/change_expression_to_volume.py
@@ -1,5 +1,13 @@
+"""
+version 1.1.0
+
+- This script will convert any expression or breath control events into volumes event based on any preceding volume events.
+"""
+
 from mido import MidiFile
+
 from small_libs.common import getMidiFile
+
 
 global currentVolume
 
@@ -11,7 +19,7 @@ def expression_to_volume(midi: MidiFile) -> None:
                 case "control_change":
                     if msg.is_cc(7):
                         currentVolume = msg.value
-                    elif msg.is_cc(11):
+                    elif msg.is_cc(2) or msg.is_cc(11):
                         newVolume = (msg.value / 127) * currentVolume
                         msg.value = int(newVolume)
                         msg.control = 7

--- a/tools/duplicate_track.py
+++ b/tools/duplicate_track.py
@@ -1,21 +1,14 @@
-import mido
-import tkinter as tk
-from tkinter import filedialog
-import small_libs.common as common
-
-root = tk.Tk()
-root.withdraw()
+from mido import MidiFile, MidiTrack
+from small_libs.common import getMidiFile
 
 
-def duplicate_track_channel(input_file, output_file, track_num, channel_num):
-    # Load the MIDI file
-    mid = mido.MidiFile(input_file)
+def duplicate_track_channel(midi, output_file, track_num, channel_num):
 
     # Create a new MIDI file to store the duplicated track
-    duplicated_track = mido.MidiTrack()
+    duplicated_track = MidiTrack()
     vacant_channels = list(range(16))
 
-    for i, track in enumerate(mid.tracks):
+    for i, track in enumerate(midi.tracks):
         for msg in track:
             if hasattr(msg, "channel") and msg.channel in vacant_channels:
                 vacant_channels = [x for x in vacant_channels if x != msg.channel]
@@ -32,21 +25,21 @@ def duplicate_track_channel(input_file, output_file, track_num, channel_num):
         duplicated_channel = vacant_channels[0]
 
     print(
-        f"Placed duplication onto Track {len(mid.tracks)}, Channel {duplicated_channel}"
+        f"Placed duplication onto Track {len(midi.tracks)}, Channel {duplicated_channel}"
     )
     for msg in duplicated_track:
         if hasattr(msg, "channel") and msg.channel == channel_num:
             msg.channel = duplicated_channel
 
-    mid.tracks.append(duplicated_track)
+    midi.tracks.append(duplicated_track)
 
     # Save the new MIDI file
-    mid.save(output_file)
+    midi.save(output_file)
 
 
 # Example usage
-input_file = common.getMidiFile()
-output_file = input_file.replace(".mid", "_duplicatedtrack.mid")
+input_file, path = getMidiFile(path=True)
+output_file = path.replace(".mid", "_duplicatedtrack.mid")
 track_num = 8  # Index of the track to duplicate
 channel_num = 6  # Channel number to duplicate
 duplicate_track_channel(input_file, output_file, track_num, channel_num)

--- a/tools/duplicate_track.py
+++ b/tools/duplicate_track.py
@@ -1,4 +1,11 @@
+"""
+Version 1.0.1
+
+- This script duplicates a desired track in a MIDI.
+"""
+
 from mido import MidiFile, MidiTrack
+
 from small_libs.common import getMidiFile
 
 
@@ -37,10 +44,9 @@ def duplicate_track_channel(midi, track_num, channel_num) -> MidiFile:
 
 
 def main() -> None:
-    # Example usage
     input_file, path = getMidiFile(path=True)
-    track_num = 8  # Index of the track to duplicate
-    channel_num = 6  # Channel number to duplicate
+    track_num = int(input("Index of the track to duplicate: "))
+    channel_num = int(input("Channel number to duplicate: "))
     output_file = duplicate_track_channel(input_file, track_num, channel_num)
     output_file.save(path.replace(".mid", "_duplicatedtrack.mid"))
 

--- a/tools/duplicate_track.py
+++ b/tools/duplicate_track.py
@@ -2,7 +2,7 @@ from mido import MidiFile, MidiTrack
 from small_libs.common import getMidiFile
 
 
-def duplicate_track_channel(midi, track_num, channel_num):
+def duplicate_track_channel(midi, track_num, channel_num) -> MidiFile:
 
     # Create a new MIDI file to store the duplicated track
     duplicated_track = MidiTrack()
@@ -36,7 +36,7 @@ def duplicate_track_channel(midi, track_num, channel_num):
     return midi
 
 
-def main():
+def main() -> None:
     # Example usage
     input_file, path = getMidiFile(path=True)
     track_num = 8  # Index of the track to duplicate

--- a/tools/duplicate_track.py
+++ b/tools/duplicate_track.py
@@ -35,6 +35,7 @@ def duplicate_track_channel(midi, track_num, channel_num):
 
     return midi
 
+
 def main():
     # Example usage
     input_file, path = getMidiFile(path=True)

--- a/tools/duplicate_track.py
+++ b/tools/duplicate_track.py
@@ -2,7 +2,7 @@ from mido import MidiFile, MidiTrack
 from small_libs.common import getMidiFile
 
 
-def duplicate_track_channel(midi, output_file, track_num, channel_num):
+def duplicate_track_channel(midi, track_num, channel_num):
 
     # Create a new MIDI file to store the duplicated track
     duplicated_track = MidiTrack()
@@ -33,13 +33,16 @@ def duplicate_track_channel(midi, output_file, track_num, channel_num):
 
     midi.tracks.append(duplicated_track)
 
-    # Save the new MIDI file
-    midi.save(output_file)
+    return midi
+
+def main():
+    # Example usage
+    input_file, path = getMidiFile(path=True)
+    track_num = 8  # Index of the track to duplicate
+    channel_num = 6  # Channel number to duplicate
+    output_file = duplicate_track_channel(input_file, track_num, channel_num)
+    output_file.save(path.replace(".mid", "_duplicatedtrack.mid"))
 
 
-# Example usage
-input_file, path = getMidiFile(path=True)
-output_file = path.replace(".mid", "_duplicatedtrack.mid")
-track_num = 8  # Index of the track to duplicate
-channel_num = 6  # Channel number to duplicate
-duplicate_track_channel(input_file, output_file, track_num, channel_num)
+if __name__ == "__main__":
+    main()

--- a/tools/fix_patch_events.py
+++ b/tools/fix_patch_events.py
@@ -12,7 +12,7 @@ from small_libs.common import getMidiFile
 from small_libs.dk64_data import VALID_CC_EVENTS
 
 
-def fix_program_changes(midi: MidiFile):
+def fix_program_changes(midi: MidiFile) -> None:
     """
     Huge function that runs through each track in an input midi file, documents all the program changes per track.
 
@@ -228,7 +228,7 @@ def fix_program_changes(midi: MidiFile):
     print()
 
 
-def main():
+def main() -> None:
     midi, path = getMidiFile(path=True)
     fix_program_changes(midi)
     midi.save(path.replace(".mid", "_patch_fixed.mid"))

--- a/tools/fix_patch_events.py
+++ b/tools/fix_patch_events.py
@@ -7,17 +7,9 @@ Version 1.1.2
   - This means that fl midis no longer need to be offset or have events at the loop to fix the patch bug!!
 """
 
-from tkinter import filedialog
-
-from mido import MidiFile
-from mido import Message
-import small_libs.common as common
-
-valid_CCs = {
-    "volume": 7,
-    "reverb": 91,
-    "pan": 10,
-}
+from mido import MidiFile, Message
+from small_libs.common import getMidiFile
+from small_libs.dk64_data import VALID_CC_EVENTS
 
 
 def fix_program_changes(midi: MidiFile):
@@ -91,11 +83,11 @@ def fix_program_changes(midi: MidiFile):
                         track_messages_less.append(msg)
                         match msg.type:
                             case "control_change":
-                                if msg.control == valid_CCs["reverb"]:
+                                if msg.control == VALID_CC_EVENTS["reverb"]:
                                     previous_reverb = msg.value
-                                if msg.control == valid_CCs["volume"]:
+                                if msg.control == VALID_CC_EVENTS["volume"]:
                                     chnl_vol = msg.value
-                                if msg.control == valid_CCs["pan"]:
+                                if msg.control == VALID_CC_EVENTS["pan"]:
                                     chnl_pan = msg.value
                             case "pitchwheel":
                                 previous_pitch = msg.pitch
@@ -122,15 +114,15 @@ def fix_program_changes(midi: MidiFile):
                             case "control_change":
 
                                 # Volume and panning are reset on patch swap, so those are compared to the default values
-                                if msg.control == valid_CCs["volume"]:
+                                if msg.control == VALID_CC_EVENTS["volume"]:
                                     patch_event_time += msg.time
                                     chnl_vol = msg.value
-                                elif msg.control == valid_CCs["pan"]:
+                                elif msg.control == VALID_CC_EVENTS["pan"]:
                                     patch_event_time += msg.time
                                     chnl_pan = msg.value
 
                                 # Reverb and pitch do not get reset and will only change the value if it has changed
-                                elif msg.control == valid_CCs["reverb"]:
+                                elif msg.control == VALID_CC_EVENTS["reverb"]:
                                     patch_event_time += msg.time
                                     if msg.value != previous_reverb:
                                         chnl_verb = msg.value
@@ -181,7 +173,7 @@ def fix_program_changes(midi: MidiFile):
                             "control_change",
                             channel=program_msg.channel,
                             time=0,
-                            control=valid_CCs["volume"],
+                            control=VALID_CC_EVENTS["volume"],
                             value=chnl_vol,
                         ),
                     )
@@ -193,7 +185,7 @@ def fix_program_changes(midi: MidiFile):
                                 "control_change",
                                 channel=program_msg.channel,
                                 time=0,
-                                control=valid_CCs["pan"],
+                                control=VALID_CC_EVENTS["pan"],
                                 value=chnl_pan,
                             ),
                         )
@@ -216,7 +208,7 @@ def fix_program_changes(midi: MidiFile):
                                 "control_change",
                                 channel=program_msg.channel,
                                 time=0,
-                                control=valid_CCs["reverb"],
+                                control=VALID_CC_EVENTS["reverb"],
                                 value=chnl_verb,
                             ),
                         )
@@ -236,14 +228,11 @@ def fix_program_changes(midi: MidiFile):
     print()
 
 
-#
-
-
-def main(midi_file: str):
-    midi = MidiFile(midi_file)
+def main():
+    midi, path = getMidiFile(path=True)
     fix_program_changes(midi)
-    midi.save(midi_file.replace(".mid", "_patch_fixed.mid"))
+    midi.save(path.replace(".mid", "_patch_fixed.mid"))
 
 
 if __name__ == "__main__":
-    main(common.getMidiFile())
+    main()

--- a/tools/fix_patch_events.py
+++ b/tools/fix_patch_events.py
@@ -1,13 +1,13 @@
 """
 Version 1.1.2
 
-
-- Deletes duplicate patch events caused by fl
+- Deletes duplicate patch events caused by FL.
   - This also condenses the subsequent events on the same tick caused by patch changes.
-  - This means that fl midis no longer need to be offset or have events at the loop to fix the patch bug!!
+  - This means that FL midis no longer need to be offset or have events at the loop to fix the patch bug!!
 """
 
 from mido import MidiFile, Message
+
 from small_libs.common import getMidiFile
 from small_libs.dk64_data import VALID_CC_EVENTS
 

--- a/tools/fix_patch_events.py
+++ b/tools/fix_patch_events.py
@@ -1,5 +1,5 @@
 """
-Version 1.1.2
+Version 1.1.3
 
 - Deletes duplicate patch events caused by FL.
   - This also condenses the subsequent events on the same tick caused by patch changes.

--- a/tools/insert_tempo.py
+++ b/tools/insert_tempo.py
@@ -1,4 +1,11 @@
+"""
+Version 1.0.0
+
+- This script simply inserts a set_tempo event into a MIDI file.
+"""
+
 from mido import MidiFile, MetaMessage
+
 from small_libs.common import getMidiFile
 
 

--- a/tools/insert_tempo.py
+++ b/tools/insert_tempo.py
@@ -1,5 +1,5 @@
 """
-Version 1.0.0
+Version 1.0.1
 
 - This script simply inserts a set_tempo event into a MIDI file.
 """

--- a/tools/insert_tempo.py
+++ b/tools/insert_tempo.py
@@ -1,22 +1,16 @@
 from mido import MidiFile, MetaMessage
-import tkinter as tk
-from tkinter import filedialog
-import small_libs.common as common
-
-root = tk.Tk()
-root.withdraw()
+from small_libs.common import getMidiFile
 
 
 def insert_tempo(midi: MidiFile):
     midi.tracks[0].insert(0, MetaMessage("set_tempo"))
 
 
-def clean_midi(midi_file: str):
-    midi = MidiFile(midi_file)
-    print("\n" + midi_file + "\n")
+def main():
+    midi, path = getMidiFile(path=True)
     insert_tempo(midi)
-    midi.save(midi_file.replace(".mid", "_tinserted.mid"))
+    midi.save(path.replace(".mid", "_tinserted.mid"))
 
 
-clean_midi(common.getMidiFile())
-input("Press the Enter key to continue: ")
+if __name__ == "__main__":
+    main()

--- a/tools/insert_tempo.py
+++ b/tools/insert_tempo.py
@@ -2,11 +2,11 @@ from mido import MidiFile, MetaMessage
 from small_libs.common import getMidiFile
 
 
-def insert_tempo(midi: MidiFile):
+def insert_tempo(midi: MidiFile) -> None:
     midi.tracks[0].insert(0, MetaMessage("set_tempo"))
 
 
-def main():
+def main() -> None:
     midi, path = getMidiFile(path=True)
     insert_tempo(midi)
     midi.save(path.replace(".mid", "_tinserted.mid"))

--- a/tools/overlap_detector.py
+++ b/tools/overlap_detector.py
@@ -13,7 +13,7 @@ from small_libs.common import getMidiFile
 
 
 # process MIDI messages
-def check_overlap(input_midi: MidiFile, sub_func: bool):
+def check_overlap(input_midi: MidiFile, sub_func: bool) -> None:
     """
     Checks for overlapping notes and prints instances of such.
     :params:
@@ -85,7 +85,7 @@ def check_overlap(input_midi: MidiFile, sub_func: bool):
         input("Press enter to close...")
 
 
-def main():
+def main() -> None:
     set_sharp_or_flat("sharp")
     check_overlap(getMidiFile(), False)
 

--- a/tools/overlap_detector.py
+++ b/tools/overlap_detector.py
@@ -1,18 +1,17 @@
 """
-Version 1.1.1
+Version 1.2.0
 
-- This script checks a MIDI file to see if there are any overlapping notes: a note on event when the last note wasn't closed.
+- This script checks a MIDI file to see if there are any overlapping notes: Two note_on events of the same note in succession without a note_off between.
 
 """
 
 import math
 from mido import MidiFile, tick2second
 import tkinter as tk
-from tkinter import filedialog
 
-import small_libs.dk64_data as dk64data
-import small_libs.notes as note_names
-import small_libs.common as common
+from small_libs.dk64_data import DK64_INSTRUMENT_LIST
+from small_libs.notes import get_note_name, set_sharp_or_flat
+from small_libs.common import getMidiFile
 
 root = tk.Tk()
 root.withdraw()
@@ -32,12 +31,12 @@ def check_overlap(input_midi: str, sub_func: bool):
     has_overlapping = False
     track_name = None
 
-    for original_track in input_midi.tracks:
+    for track_index, original_track in enumerate(input_midi.tracks):
 
         current_instrument = ""  # contains the name of the current dk64 instrument
         absolute_ticks = 0  # contains the current time when processing each event
 
-        for msg in original_track:
+        for msg_index, msg in enumerate(original_track):
 
             absolute_ticks += msg.time
 
@@ -52,8 +51,17 @@ def check_overlap(input_midi: str, sub_func: bool):
                     case "note_on":
                         if msg.note in active_notes:
                             print(
-                                f'Overlapping note!{"":9s}{note_names.get_note_name(msg.note):11s}Bar: {round(absolute_ticks / input_midi.ticks_per_beat / numerator + 1, 2):>6.2f}{"":9s}Tick: {absolute_ticks:>6d}{"":9s}Channel {msg.channel:<2d}{"":9s}"{track_name}" : {current_instrument}'
+                                f'Overlapping note!{"":9s}{get_note_name(msg.note):11s}'
+                                f'Bar: {round(absolute_ticks / input_midi.ticks_per_beat / numerator + 1, 2):>6.2f}{"":9s}'
+                                f'Tick: {absolute_ticks:>6d}{"":9s}'
+                                f'Channel {msg.channel:<2d}{"":9s}'
+                                f'{track_name if track_name is not None else f"Track {track_index}"}: {current_instrument}'
                             )
+
+                            next_msg = original_track[msg_index + 1]
+                            if next_msg.type == "note_off" and next_msg.note == msg.note and next_msg.time == 0:
+                                print("Listed overlap is 0 ticks long so no action is needed")
+                            
                             has_overlapping = True
                         else:
                             active_notes.append(msg.note)
@@ -62,9 +70,7 @@ def check_overlap(input_midi: str, sub_func: bool):
                         if msg.program >= 95:
                             current_instrument = f"Non-DK64 Instrument: {msg.program}"
                         else:
-                            current_instrument = dk64data.dk64_instrument_list[
-                                msg.program
-                            ]
+                            current_instrument = DK64_INSTRUMENT_LIST[msg.program]
 
                     case "time_signature":
                         numerator = msg.numerator
@@ -84,8 +90,8 @@ def check_overlap(input_midi: str, sub_func: bool):
 
 def main():
 
-    note_names.set_sharp_or_flat("sharp")  # 'sharp' or 'flat'
-    check_overlap(MidiFile(common.getMidiFile()), False)
+    set_sharp_or_flat("sharp")  # 'sharp' or 'flat'
+    check_overlap(getMidiFile(), False)
 
 
 if __name__ == "__main__":

--- a/tools/overlap_detector.py
+++ b/tools/overlap_detector.py
@@ -2,7 +2,6 @@
 Version 1.2.0
 
 - This script checks a MIDI file to see if there are any overlapping notes: Two note_on events of the same note in succession without a note_off between.
-
 """
 
 from mido import MidiFile

--- a/tools/overlap_detector.py
+++ b/tools/overlap_detector.py
@@ -5,23 +5,20 @@ Version 1.2.0
 
 """
 
-import math
-from mido import MidiFile, tick2second
-import tkinter as tk
+from mido import MidiFile
 
 from small_libs.dk64_data import DK64_INSTRUMENT_LIST
 from small_libs.notes import get_note_name, set_sharp_or_flat
 from small_libs.common import getMidiFile
 
-root = tk.Tk()
-root.withdraw()
-
 
 # process MIDI messages
-def check_overlap(input_midi: str, sub_func: bool):
+def check_overlap(input_midi: MidiFile, sub_func: bool):
     """
     Checks for overlapping notes and prints instances of such.
-    sub_func is a combo bool for usage of this function in another file without extra printing, pausing, ect.
+    :params:
+        `input_midi`: the MidiFile object to search through.
+        `sub_func`: a combo bool for usage of this function in another file without extra printing, pausing, ect.
     """
 
     active_notes = (
@@ -89,8 +86,7 @@ def check_overlap(input_midi: str, sub_func: bool):
 
 
 def main():
-
-    set_sharp_or_flat("sharp")  # 'sharp' or 'flat'
+    set_sharp_or_flat("sharp")
     check_overlap(getMidiFile(), False)
 
 

--- a/tools/port_tracks.py
+++ b/tools/port_tracks.py
@@ -1,4 +1,11 @@
+"""
+Version 1.0.1
+
+- This script copies a track from one MIDI file and places it into another MIDI file.
+"""
+
 from mido import MidiFile, MidiTrack
+
 from small_libs.common import getMidiFile
 
 
@@ -39,11 +46,10 @@ def copy_track(source_mid: MidiFile, dest_mid: MidiFile, track_num: int, channel
 
 
 def main() -> None:
-    # Example usage
     source_file = getMidiFile(title="Source File")
     destination_file, destination_path = getMidiFile(path=True, title="Destination File")
-    track_num = 11  # Index of the track to port
-    channel_num = 9  # Channel number to port
+    track_num = int(input("Index of the track to port: "))
+    channel_num = int(input("Channel number to port: "))
     ported_midi = copy_track(source_file, destination_file, track_num, channel_num)
     ported_midi.save(destination_path.replace(".mid", "_portedtrack.mid"))
 

--- a/tools/port_tracks.py
+++ b/tools/port_tracks.py
@@ -1,19 +1,10 @@
-import mido
-import tkinter as tk
-from tkinter import filedialog
-import small_libs.common as common
-
-root = tk.Tk()
-root.withdraw()
+from mido import MidiFile, MidiTrack
+from small_libs.common import getMidiFile
 
 
-def copy_track(file_with_track, destination_file, output_file, track_num, channel_num):
-    # Load the MIDI file
-    source_mid = mido.MidiFile(file_with_track)
-    dest_mid = mido.MidiFile(destination_file)
-
+def copy_track(source_mid: MidiFile, dest_mid: MidiFile, track_num: int, channel_num: int) -> MidiFile:
     # Create a new MIDI file to store the duplicated track
-    duplicated_track = mido.MidiTrack()
+    duplicated_track = MidiTrack()
     vacant_channels = list(range(16))
 
     for i, track in enumerate(dest_mid.tracks):
@@ -44,13 +35,18 @@ def copy_track(file_with_track, destination_file, output_file, track_num, channe
     dest_mid.tracks.append(duplicated_track)
 
     # Save the new MIDI file
-    dest_mid.save(output_file)
+    return dest_mid
 
 
-# Example usage
-source_file = common.getMidiFile()
-destination_file = filedialog.askopenfilename(title="Destination File")
-output_file = destination_file.replace(".mid", "_portedtrack.mid")
-track_num = 11  # Index of the track to port
-channel_num = 9  # Channel number to port
-copy_track(source_file, destination_file, output_file, track_num, channel_num)
+def main() -> None:
+    # Example usage
+    source_file = getMidiFile(title="Source File")
+    destination_file, destination_path = getMidiFile(path=True, title="Destination File")
+    track_num = 11  # Index of the track to port
+    channel_num = 9  # Channel number to port
+    ported_midi = copy_track(source_file, destination_file, track_num, channel_num)
+    ported_midi.save(destination_path.replace(".mid", "_portedtrack.mid"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/read_midi_file.py
+++ b/tools/read_midi_file.py
@@ -8,20 +8,7 @@ from mido import MidiFile, tempo2bpm
 
 from small_libs.dk64_data import DK64_INSTRUMENT_LIST, get_pitch_range
 from small_libs.notes import set_sharp_or_flat, get_note_name
-from small_libs.common import getMidiFile
-
-
-cc_to_name = {
-    1: "Mod Wheel",
-    5: "Portamento",
-    6: "Data Entry",
-    7: "Volume",
-    10: "Panning",
-    11: "Expression",
-    91: "Reverb",
-    100: "RPN 100",
-    101: "RPN 101",
-}
+from small_libs.common import CC_TO_NAME, getMidiFile
 
 
 def read_msg_data(track_data: list):
@@ -74,8 +61,8 @@ def read_msg_data(track_data: list):
                 )
 
             case "control_change":
-                if msg.control in cc_to_name:
-                    control_type = cc_to_name[msg.control]
+                if msg.control in CC_TO_NAME:
+                    control_type = CC_TO_NAME[msg.control]
                     match control_type:
                         case "Reverb":
                             print(

--- a/tools/read_midi_file.py
+++ b/tools/read_midi_file.py
@@ -1,7 +1,7 @@
 """
 Version 1.1.1
 
-This script reads midi data back out to you
+- This script reads MIDI data back out to you.
 """
 
 from mido import MidiFile, tempo2bpm

--- a/tools/read_midi_file.py
+++ b/tools/read_midi_file.py
@@ -1,21 +1,15 @@
 """
-Version 1.1.0
+Version 1.1.1
 
 This script reads midi data back out to you
 """
 
-from mido import MidiFile
-from mido import MidiTrack
-import tkinter as tk
-from tkinter import filedialog
-from mido import tempo2bpm
+from mido import MidiFile, tempo2bpm
 
-import small_libs.dk64_data as dk64data
-import small_libs.notes as notes
-import small_libs.common as common
+from small_libs.dk64_data import DK64_INSTRUMENT_LIST, get_pitch_range
+from small_libs.notes import set_sharp_or_flat, get_note_name
+from small_libs.common import getMidiFile
 
-root = tk.Tk()
-root.withdraw()
 
 cc_to_name = {
     1: "Mod Wheel",
@@ -53,21 +47,21 @@ def read_msg_data(track_data: list):
 
                     print(
                         f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                        f"{'Note Off (Not in DK64)':28s}{notes.get_note_name(msg.note):<28s}0"
+                        f"{'Note Off (Not in DK64)':28s}{get_note_name(msg.note):<28s}0"
                     )
 
                 else:
                     if msg.note in active_notes:
                         print(
                             f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                            f"{'Note Overlap!':28s}{notes.get_note_name(msg.note):<28s}{msg.velocity}"
+                            f"{'Note Overlap!':28s}{get_note_name(msg.note):<28s}{msg.velocity}"
                         )
                     else:
                         active_notes.append(msg.note)
 
                     print(
                         f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                        f"{'Note On':28s}{notes.get_note_name(msg.note):<28s}{msg.velocity}"
+                        f"{'Note On':28s}{get_note_name(msg.note):<28s}{msg.velocity}"
                     )
 
             case "note_off":
@@ -76,7 +70,7 @@ def read_msg_data(track_data: list):
 
                 print(
                     f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                    f"{'Note Off':28s}{notes.get_note_name(msg.note)}"
+                    f"{'Note Off':28s}{get_note_name(msg.note)}"
                 )
 
             case "control_change":
@@ -120,7 +114,7 @@ def read_msg_data(track_data: list):
                 if msg.program < 95:
                     print(
                         f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                        f"{'Program Change':28s}{dk64data.dk64_instrument_list[msg.program]:28s}{msg.program}"
+                        f"{'Program Change':28s}{DK64_INSTRUMENT_LIST[msg.program]:28s}{msg.program}"
                     )
                 else:
                     print(
@@ -132,12 +126,12 @@ def read_msg_data(track_data: list):
                 if msg.pitch < 0:
                     print(
                         f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                        f"{'Control Change':28s}{'Pitch':27s}-{round(((-msg.pitch) / 8192)* dk64data.get_pitch_range(temp_instrument), 2)} ST"
+                        f"{'Control Change':28s}{'Pitch':27s}-{round(((-msg.pitch) / 8192)* get_pitch_range(temp_instrument), 2)} ST"
                     )
                 elif msg.pitch > 0:
                     print(
                         f"{time:<8d} Ch. {msg.channel:>2d}{'':4s}"
-                        f"{'Control Change':28s}{'Pitch':27s}+{round(((msg.pitch) / 8191)* dk64data.get_pitch_range(temp_instrument), 2)} ST"
+                        f"{'Control Change':28s}{'Pitch':27s}+{round(((msg.pitch) / 8191)* get_pitch_range(temp_instrument), 2)} ST"
                     )
                 else:
                     print(
@@ -223,16 +217,13 @@ def read_single_track(midi: MidiFile, track_id):
     read_msg_data(track)
 
 
-#
-
-
-def read_midi(midi_file: str):
-    midi = MidiFile(midi_file)
-    notes.set_sharp_or_flat("sharp")  # 'sharp' or 'flat'
+def main():
+    midi = getMidiFile()
+    set_sharp_or_flat("sharp")
     read_midi_data(midi)
     # read_single_track(midi, 1)  # Track number 1-16 or 1-18 before FL fixing
     input("Press enter to close...")
 
 
 if __name__ == "__main__":
-    read_midi(common.getMidiFile())
+    main()

--- a/tools/read_midi_file.py
+++ b/tools/read_midi_file.py
@@ -11,7 +11,7 @@ from small_libs.notes import set_sharp_or_flat, get_note_name
 from small_libs.common import CC_TO_NAME, getMidiFile
 
 
-def read_msg_data(track_data: list):
+def read_msg_data(track_data: list) -> None:
     """
     reads a single MidiTrack and prints it to the console.
     """
@@ -190,7 +190,7 @@ def read_msg_data(track_data: list):
     print(f"\n{len(track_data)} events\n\n")
 
 
-def read_midi_data(midi: MidiFile):
+def read_midi_data(midi: MidiFile) -> None:
     track_number = 0
     for track in midi.tracks:
         print(f"\n= Track {track_number + 1} =\n")
@@ -198,13 +198,13 @@ def read_midi_data(midi: MidiFile):
         track_number += 1
 
 
-def read_single_track(midi: MidiFile, track_id):
+def read_single_track(midi: MidiFile, track_id) -> None:
     track_number = track_id - 1
     track = midi.tracks[track_number]
     read_msg_data(track)
 
 
-def main():
+def main() -> None:
     midi = getMidiFile()
     set_sharp_or_flat("sharp")
     read_midi_data(midi)

--- a/tools/scale_pitch.py
+++ b/tools/scale_pitch.py
@@ -1,0 +1,29 @@
+"""
+Version 1.0.1
+
+- This script multiplies all of the pitchwheel events in a MIDI file by a desired factor.
+"""
+
+from mido import MidiFile
+
+from small_libs.common import getMidiFile
+
+
+def multiply_pitch(midi: MidiFile, factor: float) -> None:
+    for track in midi.tracks:
+        for msg in track:
+            if msg.type == "pitchwheel":
+                new_pitch = round(msg.pitch * factor)
+                clamped_pitch = max(min(8191, new_pitch), -8192)
+                msg.pitch = clamped_pitch
+
+
+def main() -> None:
+    midi, path = getMidiFile(path=True)
+    factor = float(input("Scale factor: "))
+    multiply_pitch(midi, factor)
+    midi.save(path.replace(".mid", "_scaled.mid"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/shifter.py
+++ b/tools/shifter.py
@@ -1,15 +1,9 @@
-import mido
-import tkinter as tk
-from tkinter import filedialog
-import small_libs.common as common
-
-root = tk.Tk()
-root.withdraw()
+from mido import MidiFile
+from small_libs.common import getMidiFile
 
 
-def shiftMidi(midi_file: str, shift: int):
-    mid = mido.MidiFile(midi_file)
-    for track in mid.tracks:
+def shiftMidi(midi: MidiFile, path: str, shift: int):
+    for track in midi.tracks:
         performed_shift = False
         for msg in track:
             if hasattr(msg, "time"):
@@ -17,10 +11,14 @@ def shiftMidi(midi_file: str, shift: int):
                     if not performed_shift:
                         msg.time += shift
                     performed_shift = True
-    mid.save(midi_file.replace(".mid", "_shifted.mid"))
+    midi.save(path.replace(".mid", "_shifted.mid"))
+
+
+def main():
+    midi, path = getMidiFile()
+    shifty = int(input("Shift amount: "))
+    shiftMidi(midi, path, shifty)
 
 
 if __name__ == "__main__":
-    midifile = common.getMidiFile()
-    shifty = int(input("shift amount: "))
-    shiftMidi(midifile, shifty)
+    main()

--- a/tools/shifter.py
+++ b/tools/shifter.py
@@ -1,8 +1,15 @@
+"""
+Version 1.0.1
+
+- This script shifts all of the notes in a MIDI by a select amount of ticks.
+"""
+
 from mido import MidiFile
+
 from small_libs.common import getMidiFile
 
 
-def shiftMidi(midi: MidiFile, path: str, shift: int) -> MidiFile:
+def shiftMidi(midi: MidiFile, shift: int) -> MidiFile:
     for track in midi.tracks:
         performed_shift = False
         for msg in track:
@@ -17,7 +24,7 @@ def shiftMidi(midi: MidiFile, path: str, shift: int) -> MidiFile:
 def main() -> None:
     midi, path = getMidiFile()
     shifty = int(input("Shift amount: "))
-    shifted_midi = shiftMidi(midi, path, shifty)
+    shifted_midi = shiftMidi(midi, shifty)
     shifted_midi.save(path.replace(".mid", "_shifted.mid"))
 
 

--- a/tools/shifter.py
+++ b/tools/shifter.py
@@ -2,7 +2,7 @@ from mido import MidiFile
 from small_libs.common import getMidiFile
 
 
-def shiftMidi(midi: MidiFile, path: str, shift: int):
+def shiftMidi(midi: MidiFile, path: str, shift: int) -> MidiFile:
     for track in midi.tracks:
         performed_shift = False
         for msg in track:
@@ -11,13 +11,14 @@ def shiftMidi(midi: MidiFile, path: str, shift: int):
                     if not performed_shift:
                         msg.time += shift
                     performed_shift = True
-    midi.save(path.replace(".mid", "_shifted.mid"))
+    return midi
 
 
-def main():
+def main() -> None:
     midi, path = getMidiFile()
     shifty = int(input("Shift amount: "))
-    shiftMidi(midi, path, shifty)
+    shifted_midi = shiftMidi(midi, path, shifty)
+    shifted_midi.save(path.replace(".mid", "_shifted.mid"))
 
 
 if __name__ == "__main__":

--- a/tools/small_libs/common.py
+++ b/tools/small_libs/common.py
@@ -3,14 +3,14 @@ Common functions to reuse in most files, just to make starting seperate files mo
 """
 
 from mido import MidiFile, MidiTrack
-
-import tkinter as tk
 from tkinter import filedialog
 
 
-def getMidiFile():
+def getMidiFile(**path: bool):
     """
     Prompts the user for a midi file and returns a MidiFile object of that file.
+    :params: 
+        `path`: Optional. If True, will also return the prompted file's path as a string.
     """
     file = filedialog.askopenfilename(
         filetypes=[("Midi Files", "*.mid;*.midi"), ("All types", "*.*")],
@@ -19,7 +19,10 @@ def getMidiFile():
     if file == "":
         print("No file presented, closing...")
         exit(0)
-    return MidiFile(file)
+    if path:
+        return MidiFile(file), file
+    else:
+        return MidiFile(file)
 
 
 def find_tempo_track(midi: MidiFile):

--- a/tools/small_libs/common.py
+++ b/tools/small_libs/common.py
@@ -2,8 +2,21 @@
 Common functions to reuse in most files, just to make starting seperate files more consistant and nice.
 """
 
-from mido import MidiFile, MidiTrack
+from mido import MidiFile
 from tkinter import filedialog
+
+
+CC_TO_NAME = {
+    1: "Mod Wheel",
+    5: "Portamento",
+    6: "Data Entry",
+    7: "Volume",
+    10: "Panning",
+    11: "Expression",
+    91: "Reverb",
+    100: "RPN 100",
+    101: "RPN 101",
+}
 
 
 def getMidiFile(**kwargs):

--- a/tools/small_libs/common.py
+++ b/tools/small_libs/common.py
@@ -2,14 +2,16 @@
 Common functions to reuse in most files, just to make starting seperate files more consistant and nice.
 """
 
-from mido import MidiFile
-from mido import MidiTrack
+from mido import MidiFile, MidiTrack
 
 import tkinter as tk
 from tkinter import filedialog
 
 
 def getMidiFile():
+    """
+    Prompts the user for a midi file and returns a MidiFile object of that file.
+    """
     file = filedialog.askopenfilename(
         filetypes=[("Midi Files", "*.mid;*.midi"), ("All types", "*.*")],
         title="Source File",
@@ -17,7 +19,7 @@ def getMidiFile():
     if file == "":
         print("No file presented, closing...")
         exit(0)
-    return file
+    return MidiFile(file)
 
 
 def find_tempo_track(midi: MidiFile):

--- a/tools/small_libs/common.py
+++ b/tools/small_libs/common.py
@@ -6,23 +6,24 @@ from mido import MidiFile, MidiTrack
 from tkinter import filedialog
 
 
-def getMidiFile(**path: bool):
+def getMidiFile(**kwargs):
     """
     Prompts the user for a midi file and returns a MidiFile object of that file.
     :params: 
-        `path`: Optional. If True, will also return the prompted file's path as a string.
+        `path`: `Optional[bool]`. If True, will also return the prompted file's path as a string.
+        `title`: `Optional[str]` the title for the tkinter dialog box.
     """
     file = filedialog.askopenfilename(
         filetypes=[("Midi Files", "*.mid;*.midi"), ("All types", "*.*")],
-        title="Source File",
+        title=kwargs["title"] if "title" in kwargs else "Source File",
     )
     if file == "":
         print("No file presented, closing...")
         exit(0)
-    if path:
-        return MidiFile(file), file
-    else:
-        return MidiFile(file)
+    if "path" in kwargs:
+        if kwargs["path"]:
+            return MidiFile(file), file
+    return MidiFile(file)
 
 
 def find_tempo_track(midi: MidiFile):

--- a/tools/small_libs/dk64_data.py
+++ b/tools/small_libs/dk64_data.py
@@ -2,10 +2,10 @@
 Separated out dk64 music related data for quick reference in other files / future files
 """
 
-max_voices = 44
+MAX_VOICES = 44
 """max voices dk64 can play at once"""
 
-reverb_tail = 2334000
+REVERB_TAIL = 2334000
 """length of reverb tail in microseconds"""
 
 
@@ -54,7 +54,7 @@ def get_pitch_range(instrument: int):
             return 2
 
 
-dk64_instrument_list = [
+DK64_INSTRUMENT_LIST = [
     "N/A",
     "Marimba",
     "Rototom",

--- a/tools/small_libs/dk64_data.py
+++ b/tools/small_libs/dk64_data.py
@@ -1,13 +1,20 @@
 """
-Separated out dk64 music related data for quick reference in other files / future files
+Separated out dk64 music related data for quick reference in other files / future files.
 """
 
 MAX_VOICES = 44
-"""max voices dk64 can play at once"""
+"""Max voices dk64 can play at once."""
 
 REVERB_TAIL = 2334000
-"""length of reverb tail in microseconds"""
+"""Length of reverb tail in microseconds."""
 
+VALID_CC_EVENTS = {
+    "volume": 7,
+    "pan": 10,
+    "portamento": 65, # useless, but might as well
+    "reverb": 91,
+}
+"""Control change events that DK64 recognises."""
 
 def get_instrument_release(instrument: int):
     """
@@ -27,7 +34,7 @@ def get_instrument_release(instrument: int):
 
 def get_pitch_range(instrument: int):
     """
-    returns pitch bend range in ±Semitones based on instrument patch/instrument number
+    Returns pitch bend range in ±Semitones based on instrument patch/instrument number.
     """
 
     match instrument:

--- a/tools/small_libs/notes.py
+++ b/tools/small_libs/notes.py
@@ -6,9 +6,9 @@ Reminder: use set_sharp_or_flat(...) before get_note_name(...), or don't :3
 note_names = ["Do", "Di", "Re", "Ri", "Mi", "Fa", "Fi", "Sol", "Si", "La", "Li", "Ti"]
 
 
-def set_sharp_or_flat(sign: str):
+def set_sharp_or_flat(sign: str) -> None:
     """
-    Sets the sign for the notes to 'sharp' or 'flat'
+    Sets the sign for the notes to `"sharp"` or `"flat"`
     """
 
     global note_names
@@ -44,10 +44,9 @@ def set_sharp_or_flat(sign: str):
         ]
 
 
-def get_note_name(note: int):
+def get_note_name(note: int) -> str:
     """
     Retrieves the note name from the Midi note number.
     """
-
     note_name = f"{ note_names[note % 12] }{ int(note / 12) }"
     return note_name

--- a/tools/to_type_1.py
+++ b/tools/to_type_1.py
@@ -1,19 +1,11 @@
-import mido
-import os
-import tkinter as tk
-from tkinter import filedialog
+from mido import MidiFile
+from small_libs.common import getMidiFile
 
-root = tk.Tk()
-root.withdraw()
 
-OLD_MIDI = filedialog.askopenfilename()
-NEW_MIDI = OLD_MIDI.replace(".mid","_converted.mid")
-
-def convert_type0_type1(midi_type0_file):
-    type_0 = mido.MidiFile(midi_type0_file)
+def convert_type0_type1(type_0: MidiFile) -> MidiFile:
     if type_0.type != 0:
-        return
-    type_1 = mido.MidiFile(
+        raise TypeError("MIDI must be type 0")
+    type_1 = MidiFile(
         type=1,
         ticks_per_beat=type_0.ticks_per_beat)
     time = 0
@@ -41,6 +33,14 @@ def convert_type0_type1(midi_type0_file):
         track = type_1.add_track()
         track.extend(channels[chan]['msg'])
 
-    type_1.save(NEW_MIDI)
+    return type_1
 
-convert_type0_type1(OLD_MIDI)
+
+def main():
+    OLD_MIDI, path = getMidiFile()
+    NEW_MIDI = convert_type0_type1(OLD_MIDI)
+    NEW_MIDI.save(path.replace(".mid", "_converted.mid"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/to_type_1.py
+++ b/tools/to_type_1.py
@@ -36,7 +36,7 @@ def convert_type0_type1(type_0: MidiFile) -> MidiFile:
     return type_1
 
 
-def main():
+def main() -> None:
     OLD_MIDI, path = getMidiFile()
     NEW_MIDI = convert_type0_type1(OLD_MIDI)
     NEW_MIDI.save(path.replace(".mid", "_converted.mid"))

--- a/tools/to_type_1.py
+++ b/tools/to_type_1.py
@@ -1,4 +1,11 @@
+"""
+Version 1.0.1
+
+- This script converts a type 0 MIDI into a type 1 MIDI.
+"""
+
 from mido import MidiFile
+
 from small_libs.common import getMidiFile
 
 

--- a/tools/unscramble.py
+++ b/tools/unscramble.py
@@ -136,7 +136,7 @@ def unscramble(old_midi: MidiFile) -> MidiFile:
     return completed_midi
 
 
-def main():
+def main() -> None:
     old_midi, path = getMidiFile(path=True)
     if old_midi.type == 0:
         raise TypeError("MIDI must be type 1")

--- a/tools/unscramble.py
+++ b/tools/unscramble.py
@@ -1,4 +1,11 @@
+"""
+Version 1.0.1
+
+- This script attempts to sort a MIDI by seperating each detected program change into its own track.
+"""
+
 from mido import MidiFile, MidiTrack, Message, MetaMessage, merge_tracks
+
 from small_libs.common import getMidiFile
 
 

--- a/tools/unscramble.py
+++ b/tools/unscramble.py
@@ -1,9 +1,6 @@
 from mido import MidiFile, MidiTrack, Message, MetaMessage, merge_tracks
-import tkinter as tk
-from tkinter import filedialog
+from small_libs.common import getMidiFile
 
-root = tk.Tk()
-root.withdraw()
 
 def find_correct_track(detected_programs: dict, current_program: int) -> int:
     """Reverse lookup to find the current track number."""
@@ -11,6 +8,7 @@ def find_correct_track(detected_programs: dict, current_program: int) -> int:
         if detected_programs.get(j+1) == current_program: # until it finds the track with the correct program value
             return j+1
     return 0 # if no match is found, toss it in the first track along with tempo
+
 
 def search_dict(global_detected_programs: dict) -> dict:
     """Searches global_detected_programs for entries with matching values and returns a dict of the matches."""
@@ -35,11 +33,13 @@ def search_dict(global_detected_programs: dict) -> dict:
 
     return matching_tracks
 
+
 def cipher_key(matching_cipher: dict, current_program: int) -> int:
     """Surely theres a simpler way to do this"""
     for j in range(len(matching_cipher)):
         if matching_cipher.get(j) == current_program:
             return j
+
 
 def unscramble(old_midi: MidiFile) -> MidiFile:
     """This attempts to sort a midi by seperating each detected program change into its own track."""
@@ -134,14 +134,15 @@ def unscramble(old_midi: MidiFile) -> MidiFile:
             c = 0
         i += 1
     return completed_midi
-    
 
-def clean_midi(midi_file: str):
-    old_midi = MidiFile(midi_file)
+
+def main():
+    old_midi, path = getMidiFile(path=True)
     if old_midi.type == 0:
         raise TypeError("MIDI must be type 1")
-    print("\n" + midi_file + "\n")
     new_midi = unscramble(old_midi)
-    new_midi.save(midi_file.replace(".mid", "_sorted.mid"))
+    new_midi.save(path.replace(".mid", "_sorted.mid"))
 
-clean_midi(filedialog.askopenfilename())
+
+if __name__ == "__main__":
+    main()

--- a/tools/voice_counter.py
+++ b/tools/voice_counter.py
@@ -12,7 +12,7 @@ from small_libs.common import CC_TO_NAME, getMidiFile
 
 
 # process MIDI messages
-def check_voices(input_midi: MidiFile, sub_func: bool):
+def check_voices(input_midi: MidiFile, sub_func: bool) -> None:
     """
     Checks for voice count and prints if the max is reached.
     sub_func is a combo bool for usage of this function in another file without extra printing, pausing.
@@ -94,7 +94,7 @@ def check_voices(input_midi: MidiFile, sub_func: bool):
         input("Press enter to close...")
 
 
-def main():
+def main() -> None:
     set_sharp_or_flat("sharp")
     check_voices(getMidiFile(), False)
 

--- a/tools/voice_counter.py
+++ b/tools/voice_counter.py
@@ -8,20 +8,7 @@ from mido import MidiFile
 
 from small_libs.dk64_data import REVERB_TAIL, MAX_VOICES, get_instrument_release
 from small_libs.notes import set_sharp_or_flat
-from small_libs.common import getMidiFile
-
-
-cc_to_name = {
-    1: "Mod Wheel",
-    5: "Portamento",
-    6: "Data Entry",
-    7: "Volume",
-    10: "Panning",
-    11: "Expression",
-    91: "Reverb",
-    100: "RPN 100",
-    101: "RPN 101",
-}
+from small_libs.common import CC_TO_NAME, getMidiFile
 
 
 # process MIDI messages
@@ -82,7 +69,7 @@ def check_voices(input_midi: MidiFile, sub_func: bool):
                 tempo = msg.tempo
 
             elif msg.type == "control_change":
-                if cc_to_name[msg.control] == "Reverb" and msg.value > 0:
+                if CC_TO_NAME[msg.control] == "Reverb" and msg.value > 0:
                     reverb = True
 
     all_times = sorted(note_events)

--- a/tools/voice_counter.py
+++ b/tools/voice_counter.py
@@ -1,7 +1,7 @@
 """
 Version 1.0.1
 
-- This script checks a MIDI file to see if there are any instances if too many notes playing at once, breakingDK64's engine.
+- This script checks a MIDI file to see if there are any instances if too many notes playing at once, breaking DK64's engine.
 """
 
 from mido import MidiFile

--- a/tools/voice_counter.py
+++ b/tools/voice_counter.py
@@ -4,17 +4,11 @@ Version 1.0.1
 - This script checks a MIDI file to see if there are any instances if too many notes playing at once, breakingDK64's engine.
 """
 
-import math
-from mido import MidiFile, tick2second
-import tkinter as tk
-from tkinter import filedialog
+from mido import MidiFile
 
-import small_libs.dk64_data as dk64data
-import small_libs.notes as note_names
-import small_libs.common as common
-
-root = tk.Tk()
-root.withdraw()
+from small_libs.dk64_data import REVERB_TAIL, MAX_VOICES, get_instrument_release
+from small_libs.notes import set_sharp_or_flat
+from small_libs.common import getMidiFile
 
 
 cc_to_name = {
@@ -31,7 +25,7 @@ cc_to_name = {
 
 
 # process MIDI messages
-def check_voices(input_midi: str, sub_func: bool):
+def check_voices(input_midi: MidiFile, sub_func: bool):
     """
     Checks for voice count and prints if the max is reached.
     sub_func is a combo bool for usage of this function in another file without extra printing, pausing.
@@ -59,12 +53,12 @@ def check_voices(input_midi: str, sub_func: bool):
             if msg.type == "note_off":
 
                 note_release_ticks = round(
-                    (dk64data.get_instrument_release(instrument) / tempo)
+                    (get_instrument_release(instrument) / tempo)
                     * input_midi.ticks_per_beat
                 )
                 if reverb:
                     note_release_ticks = round(
-                        (dk64data.reverb_tail / tempo) * input_midi.ticks_per_beat
+                        (REVERB_TAIL / tempo) * input_midi.ticks_per_beat
                     )
 
                 if (absolute_ticks + note_release_ticks) in note_events:
@@ -95,18 +89,18 @@ def check_voices(input_midi: str, sub_func: bool):
     for time in all_times:
         active_voices += note_events.get(time)
         peak_voices = max(peak_voices, active_voices)
-        if (active_voices > dk64data.max_voices) and not sub_func:
+        if (active_voices > MAX_VOICES) and not sub_func:
             print(
                 f'{active_voices} Voices{"":9s}Bar: {round(absolute_ticks / input_midi.ticks_per_beat / numerator + 1, 2):>6.2f}{"":6s}Tick: {absolute_ticks:>6d}'
             )
 
-    if peak_voices <= dk64data.max_voices:
+    if peak_voices <= MAX_VOICES:
         print(
-            f"\nThe voices only reached a peak of {peak_voices} out of {dk64data.max_voices} availible!\n"
+            f"\nThe voices only reached a peak of {peak_voices} out of {MAX_VOICES} availible!\n"
         )
     else:
         print(
-            f"\nThe voices hit a peak of {peak_voices} out of {dk64data.max_voices} availible!\nThis will need to be fixed or notes will be dropped in game!\n"
+            f"\nThe voices hit a peak of {peak_voices} out of {MAX_VOICES} availible!\nThis will need to be fixed or notes will be dropped in game!\n"
         )
 
     if not sub_func:
@@ -114,9 +108,8 @@ def check_voices(input_midi: str, sub_func: bool):
 
 
 def main():
-
-    note_names.set_sharp_or_flat("sharp")  # 'sharp' or 'flat'
-    check_voices(MidiFile(common.getMidiFile()), False)
+    set_sharp_or_flat("sharp")
+    check_voices(getMidiFile(), False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Refactors
- Every script now has a description and version tracking.
- Every script now uses `__name__ == "__main__"` as their starting point.
- Moved some global variables in various script in the `small_libs` module.
- `small_libs` variables/functions are now imported directly as to remove need to reference the module every time.
- Removed useless tkinter imports in every script.
- `getMidiFile()` now returns a MidiFile object directly, plus some added keyword argument functionality.
- Refactored how scripts load midis in accordance to `getMidiFile()` changes.
- Added type hints to every function.
- Other general formatting changes.
## Actual script changes
- Added `scale_pitch.py` which is another script I had laying around.
- `change_expression_to_volume.py` now takes in breath control events as well.
- `overlap_detector.py` now reports an edge case of an overlap being 0 ticks long. Fixes #3 